### PR TITLE
Use puppetdb_gc module instead of gc-interval on puppetdb

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,6 +8,7 @@ mod "puppetlabs/concat",      '2.2.0'
 mod "puppet/hiera",           '2.1.2'
 mod "npwalker/pe_code_manager_webhook",  '1.0.12'
 mod "npwalker/pe_metric_curl_cron_jobs", '1.0.2'
+mod "npwalker/puppetdb_gc", '0.9.0'
 
 # Modules from Github using various references
 # Further examples: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#examples

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,3 +9,6 @@ puppet_enterprise::master::code_manager::authenticate_webhook: false
 #https://docs.puppetlabs.com/pe/latest/console_config.html#tuning-the-classifier-synchronization-period
 #disable classifier scheduled sync and rely on r10k postrun command to sync the classes
 puppet_enterprise::profile::console::classifier_synchronization_period: 0
+
+#disable gc-interval because we're using the puppetdb_gc module
+puppet_enterprise::profile::puppetdb::gc_interval: 0

--- a/site/role/manifests/all_in_one_pe.pp
+++ b/site/role/manifests/all_in_one_pe.pp
@@ -3,5 +3,6 @@ class role::all_in_one_pe {
   include profile::puppetmaster
   include pe_code_manager_webhook
   include pe_metric_curl_cron_jobs
+  include puppetdb_gc
 
 }


### PR DESCRIPTION
This commit adds the puppetdb_gc module which manages puppetdb
garbage collection via cron jobs that run specific portions of
pdb garbage collection at different intervals than the default in
puppetdb which is to run all garbage collections queries at the
same time.  Part of implementing the module includes disable the
gc-interval on puppetdb via hieradata.