### PR TITLE
added puppet_enterprise::master::code_manager::manage_private_key: fa…

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -4,7 +4,7 @@ message: "This node is using common data"
 #Enable code manager
 puppet_enterprise::profile::master::code_manager_auto_configure: true
 puppet_enterprise::master::code_manager::authenticate_webhook: false
-
+puppet_enterprise::master::code_manager::manage_private_key: false
 #pe-console-services tuning
 #https://docs.puppetlabs.com/pe/latest/console_config.html#tuning-the-classifier-synchronization-period
 #disable classifier scheduled sync and rely on r10k postrun command to sync the classes


### PR DESCRIPTION
In 2017.2, the code manager module and the webhook module both declare the private_key causing puppet agent to fail immediately after loading the ramp-up repo, setting the flag to false resolves this.
