### PR TITLE
removed classifier_synchronization_period override

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -8,4 +8,4 @@ puppet_enterprise::master::code_manager::manage_private_key: false
 #pe-console-services tuning
 #https://docs.puppetlabs.com/pe/latest/console_config.html#tuning-the-classifier-synchronization-period
 #disable classifier scheduled sync and rely on r10k postrun command to sync the classes
-puppet_enterprise::profile::console::classifier_synchronization_period: 0
+#puppet_enterprise::profile::console::classifier_synchronization_period: 0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,7 +5,3 @@ message: "This node is using common data"
 puppet_enterprise::profile::master::code_manager_auto_configure: true
 puppet_enterprise::master::code_manager::authenticate_webhook: false
 puppet_enterprise::master::code_manager::manage_private_key: false
-#pe-console-services tuning
-#https://docs.puppetlabs.com/pe/latest/console_config.html#tuning-the-classifier-synchronization-period
-#disable classifier scheduled sync and rely on r10k postrun command to sync the classes
-#puppet_enterprise::profile::console::classifier_synchronization_period: 0


### PR DESCRIPTION
r10k postrun command is not called when using code manager disabling classifier scheduled sync results in the classifier never syncing automatically